### PR TITLE
feat(cli): adding preview and start commands

### DIFF
--- a/.changeset/blue-cycles-smoke.md
+++ b/.changeset/blue-cycles-smoke.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/create-eventcatalog": patch
+---
+
+feat(cli): adding preview and start commands

--- a/templates/index.ts
+++ b/templates/index.ts
@@ -41,10 +41,10 @@ export const installTemplate = async ({
     version: "0.1.0",
     private: true,
     scripts: {
-      start: "eventcatalog start",
       dev: "eventcatalog dev",
       build: "eventcatalog build",
-      generate: "eventcatalog generate",
+      start: "eventcatalog start",
+      preview: "eventcatalog preview",
       test: 'echo "Error: no test specified" && exit 1',
     },
     dependencies: {


### PR DESCRIPTION
When creating a new catalog the commands preview and start are now populated.