### PR TITLE
feat: add cross-env to devDependencies

### DIFF
--- a/templates/index.ts
+++ b/templates/index.ts
@@ -74,6 +74,7 @@ export const installTemplate = async ({
   const devDependencies = [
     "@parcel/watcher",
     "concurrently",
+    "cross-env",
   ] as any;
 
   /**


### PR DESCRIPTION
It adds cross-env to devDependencies for work with Windows OS.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

Happy contributing!

-->

## Motivation

Windows OS need `cross-env` installed as devDependecies to work properly.
