### PR TITLE
fix(deps): add missing stoplight devdependencies

### DIFF
--- a/.changeset/wild-candles-glow.md
+++ b/.changeset/wild-candles-glow.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/create-eventcatalog": patch
+---
+
+fix(deps): add missing stoplight dev dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@eventcatalog/create-eventcatalog",
-  "version": "2.0.0",
+  "version": "2.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@eventcatalog/create-eventcatalog",
-      "version": "2.0.0",
+      "version": "2.0.11",
       "dependencies": {
         "@changesets/cli": "^2.27.6"
       },

--- a/templates/index.ts
+++ b/templates/index.ts
@@ -1,10 +1,10 @@
 import { copy } from "../helpers/copy";
 import { install } from "../helpers/install";
 
-import os from "os";
-import fs from "fs";
-import path from "path";
 import chalk from "chalk";
+import fs from "fs";
+import os from "os";
+import path from "path";
 
 import { GetTemplateFileArgs, InstallTemplateArgs } from "./types";
 
@@ -76,6 +76,8 @@ export const installTemplate = async ({
     "concurrently",
     "cross-env",
     "@types/lodash.merge",
+    "@stoplight/markdown-viewer",
+    "@stoplight/mosaic-code-viewer",
   ] as any;
 
   /**


### PR DESCRIPTION
Resolves #32 

## Motivation

When starting a new project, the template is missing a couple development dependencies which causes some errors when starting up.
This resolves the issue by adding the two missing packages.

Also switches around some imports because that's what my IDE wanted to do...  :facepalm: 