### PR TITLE
chore(cli): removing dev deps no longer required

### DIFF
--- a/.changeset/four-olives-arrive.md
+++ b/.changeset/four-olives-arrive.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/create-eventcatalog": patch
+---
+
+chore(cli): removing dev deps no longer required

--- a/templates/index.ts
+++ b/templates/index.ts
@@ -74,13 +74,7 @@ export const installTemplate = async ({
   // const dependencies = ["@eventcatalog/eventcatalog-2"];
   const dependencies = [] as any;
   // "@myuser/my-package": "file:../lib"
-  const devDependencies = [
-    "@parcel/watcher",
-    "concurrently",
-    "cross-env",
-    "@types/lodash.merge",
-    "@types/diff",
-  ] as any;
+  const devDependencies = [] as any;
 
   /**
    * Install package.json dependencies if they exist.


### PR DESCRIPTION
Removing dev deps that are no longer required as they are now bundles with EventCatalog