### PR TITLE
feat/organization-name-option

### DIFF
--- a/.changeset/few-fans-wonder.md
+++ b/.changeset/few-fans-wonder.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/create-eventcatalog": patch
+---
+
+feat(cli): added ability to set org name through CLI command

--- a/index.ts
+++ b/index.ts
@@ -18,8 +18,9 @@ const program = new Commander.Command(packageJson.name)
   .version(packageJson.version)
   .arguments("<project-directory>")
   .usage(`${chalk.green("<project-directory>")} [options]`)
-  .action((name) => {
+  .action((name, options) => {
     projectPath = name;
+    organizationName = options.organizationName || "";
   })
   .option(
     "--ts, --typescript",
@@ -80,6 +81,13 @@ const program = new Commander.Command(packageJson.name)
   a slash (e.g. bug/fix-1) and the path to the example (e.g. foo/bar).
   In this case, you must specify the path to the example separately:
   --example-path foo/bar
+`,
+  )
+  .option(
+    "--organization-name [name]",
+    `
+
+  The organization name.
 `,
   )
   .allowUnknownOption()


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://www.eventcatalog.dev/docs/contributing/overview

Happy contributing!

-->

## Motivation

It adds a command option to set the organization name, avoiding prompting. 

This solves this problem mentioned [here](https://discord.com/channels/918092420338569216/929038812175278091/1289305848497180774)