### PR TITLE
chore(sdk): added docker file for a server catalog

### DIFF
--- a/.changeset/afraid-dodos-happen.md
+++ b/.changeset/afraid-dodos-happen.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/create-eventcatalog": patch
+---
+
+chore(sdk): added docker file for a server catalog

--- a/templates/asyncapi/Dockerfile.server
+++ b/templates/asyncapi/Dockerfile.server
@@ -1,0 +1,23 @@
+# Use this Docker file if your EventCatalog output is set to `server`.
+# When EventCatalog output is set to `server`, the output will be a node server.
+# This server is required for certain features like the EventCatalog Chat (with your own keys).
+
+FROM node:lts AS runtime
+WORKDIR /app
+
+# Install dependencies
+COPY package.json package-lock.json ./
+RUN npm install
+
+COPY . .
+
+# Fix for Astro in Docker: https://github.com/withastro/astro/issues/2596
+ENV NODE_OPTIONS=--max_old_space_size=2048
+RUN npm run build
+
+ENV HOST=0.0.0.0
+ENV PORT=3000
+EXPOSE 3000
+
+# Start the server
+CMD npm run start

--- a/templates/default/Dockerfile.server
+++ b/templates/default/Dockerfile.server
@@ -1,0 +1,23 @@
+# Use this Docker file if your EventCatalog output is set to `server`.
+# When EventCatalog output is set to `server`, the output will be a node server.
+# This server is required for certain features like the EventCatalog Chat (with your own keys).
+
+FROM node:lts AS runtime
+WORKDIR /app
+
+# Install dependencies
+COPY package.json package-lock.json ./
+RUN npm install
+
+COPY . .
+
+# Fix for Astro in Docker: https://github.com/withastro/astro/issues/2596
+ENV NODE_OPTIONS=--max_old_space_size=2048
+RUN npm run build
+
+ENV HOST=0.0.0.0
+ENV PORT=3000
+EXPOSE 3000
+
+# Start the server
+CMD npm run start

--- a/templates/empty/Dockerfile.server
+++ b/templates/empty/Dockerfile.server
@@ -1,0 +1,23 @@
+# Use this Docker file if your EventCatalog output is set to `server`.
+# When EventCatalog output is set to `server`, the output will be a node server.
+# This server is required for certain features like the EventCatalog Chat (with your own keys).
+
+FROM node:lts AS runtime
+WORKDIR /app
+
+# Install dependencies
+COPY package.json package-lock.json ./
+RUN npm install
+
+COPY . .
+
+# Fix for Astro in Docker: https://github.com/withastro/astro/issues/2596
+ENV NODE_OPTIONS=--max_old_space_size=2048
+RUN npm run build
+
+ENV HOST=0.0.0.0
+ENV PORT=3000
+EXPOSE 3000
+
+# Start the server
+CMD npm run start

--- a/templates/openapi/Dockerfile.server
+++ b/templates/openapi/Dockerfile.server
@@ -1,0 +1,23 @@
+# Use this Docker file if your EventCatalog output is set to `server`.
+# When EventCatalog output is set to `server`, the output will be a node server.
+# This server is required for certain features like the EventCatalog Chat (with your own keys).
+
+FROM node:lts AS runtime
+WORKDIR /app
+
+# Install dependencies
+COPY package.json package-lock.json ./
+RUN npm install
+
+COPY . .
+
+# Fix for Astro in Docker: https://github.com/withastro/astro/issues/2596
+ENV NODE_OPTIONS=--max_old_space_size=2048
+RUN npm run build
+
+ENV HOST=0.0.0.0
+ENV PORT=3000
+EXPOSE 3000
+
+# Start the server
+CMD npm run start


### PR DESCRIPTION
Added a new docker file `DockerFile.server` for EventCatalogs that need to be run on a Server (output set to `server`)